### PR TITLE
Add debug to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "colors": "^1.1.2",
+    "debug": "^3.1.0",
     "is-ci": "^1.0.10",
     "lodash": "^4.17.4",
     "normalize-path": "^1.0.0",


### PR DESCRIPTION
This PR:
- adds debug module to the list of dependencies to fix the following error:

```
➜  npm i --save-dev gint

> gint@0.9.1 install node_modules/gint
> node ./bin/install.js

module.js:491
    throw err;
    ^

Error: Cannot find module 'debug'
    at Function.Module._resolveFilename (module.js:489:15)
    at Function.Module._load (module.js:439:25)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (node_modules/gint/lib/setup/hook-script.js:5:15)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
```